### PR TITLE
Add query filtering and pagination to GET /transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
 # blockchain-api
-A blockchain api using MongoDB
+A blockchain API using MongoDB
+
+## API Endpoints
+
+### GET /transactions
+
+Returns transactions stored in the MongoDB database with optional filtering and pagination.
+
+#### Query Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `sender` | string | No | - | Filter by sender address |
+| `receiver` | string | No | - | Filter by receiver address |
+| `amount` | integer | No | - | Filter by exact amount |
+| `limit` | integer | No | 10 | Number of results to return (max: 50) |
+| `offset` | integer | No | 0 | Number of results to skip |
+
+#### Examples
+
+**Get all transactions (first 10):**
+```bash
+curl http://localhost:3000/transactions
+```
+
+**Filter by sender:**
+```bash
+curl "http://localhost:3000/transactions?sender=Alice"
+```
+
+**Filter by receiver:**
+```bash
+curl "http://localhost:3000/transactions?receiver=Bob""
+```
+
+**Filter by amount:**
+```bash
+curl "http://localhost:3000/transactions?amount=100"
+```
+
+**Pagination - get transactions 11-20::**
+```bash
+curl "http://localhost:3000/transactions?limit=10&offset=10"
+```
+
+**Combined filtering and pagination:**
+``` bash
+curl "http://localhost:3000/transactions?sender=Alice&limit=5"
+```
+
+**Response format**
+```
+{
+  "transactions": [
+    {
+      "_id": { "$oid": "..." },
+      "tx_id": 1759218067668,
+      "sender": "Alice",
+      "receiver": "Bob",
+      "amount": 100,
+      "timestamp": 1759218067
+    }
+  ],
+  "count": 1
+}
+```

--- a/src/handlers/transaction.rs
+++ b/src/handlers/transaction.rs
@@ -97,9 +97,23 @@ pub async fn get_transactions(State(client): State<Client>, Query(params): Query
     let database = client.database("blockchain");
     let collection = database.collection("transactions");
 
-    // Step 1: Get limit and offset
+    // Step 1: Get limit, offset and filters
     let limit = params.get_limit();
     let offset = params.get_offset();
+    let mut filter = doc! {};
+
+    if let Some(sender) = &params.sender {
+            filter.insert("sender", sender);
+    }
+
+    if let Some(receiver) = &params.receiver {
+            filter.insert("receiver", receiver);
+    }
+
+    if let Some(amount) = &params.amount {
+            filter.insert("amount", amount);
+    }
+
 
     // Step 2: Build FindOptions
     let find_options = FindOptions::builder()
@@ -109,7 +123,7 @@ pub async fn get_transactions(State(client): State<Client>, Query(params): Query
 
     // Step 3: Use them in find
     let mut cursor = collection
-        .find(doc! {})
+        .find(filter)
         .with_options(find_options)
         .await
         .map_err(|e| AppError::Database(format!("Failed to query transaction: {}", e)))?;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,6 +1,9 @@
 pub mod block;
 pub mod blockchain;
 pub mod transaction;
+pub mod query;
+
 pub use block::Block;
 pub use blockchain::Blockchain;
 pub use transaction::Transaction;
+pub use query::TransactionQuery;

--- a/src/models/query.rs
+++ b/src/models/query.rs
@@ -15,10 +15,17 @@ pub struct TransactionQuery {
 impl TransactionQuery {
     /// Get the limit with default value and maximum cap
     pub fn get_limit(&self) -> u64 {
-        //todo
+        match self.limit {
+            Some(limit_value) if limit_value > 50 => 50,
+            Some(limit_value) => limit_value,
+            None => 10,
+        }
     }
     // Get the offset with default value
     pub fn get_offset(&self) -> u64 {
-        //todo
+        match self.offset {
+            Some(offset_value) => offset_value,
+            None => 0,
+        }
     }
 }

--- a/src/models/query.rs
+++ b/src/models/query.rs
@@ -5,7 +5,7 @@ pub struct TransactionQuery {
     //Filtering parameters, all optional
     pub sender: Option<String>,
     pub receiver: Option<String>,
-    pub amount: Option<u64>,
+    pub amount: Option<i64>,
 
     //Pagination params, all optional
     pub limit: Option<u64>,

--- a/src/models/query.rs
+++ b/src/models/query.rs
@@ -1,0 +1,24 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct TransactionQuery {
+    //Filtering parameters, all optional
+    pub sender: Option<String>,
+    pub receiver: Option<String>,
+    pub amount: Option<u64>,
+
+    //Pagination params, all optional
+    pub limit: Option<u64>,
+    pub offset: Option<u64>,
+}
+
+impl TransactionQuery {
+    /// Get the limit with default value and maximum cap
+    pub fn get_limit(&self) -> u64 {
+        //todo
+    }
+    // Get the offset with default value
+    pub fn get_offset(&self) -> u64 {
+        //todo
+    }
+}


### PR DESCRIPTION
Closes #14

## Changes:
- Added query parameters: sender, receiver, amount, limit, offset
- Implemented dynamic MongoDB filtering
- Added pagination with defaults (limit=10, max=50)
- Tested all filtering and pagination combinations
- Added comprehensive API documentation

## Testing:
- ✅ Filter by sender
- ✅ Filter by receiver
- ✅ Filter by amount
- ✅ Pagination (limit/offset)
- ✅ Combined filtering + pagination
- ✅ Limit cap at 50