### PR TITLE
Add OpenAPI/Swagger documentation for all endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,5 @@ tower = "0.5.2"
 mongodb = "3.2.3"
 futures-util = "0.3.31"
 rand = "0.8"
+utoipa = { version = "5.4", features = ["axum_extras"] }
+utoipa-swagger-ui = { version = "9.0", features = ["axum"] }

--- a/src/handlers/transaction.rs
+++ b/src/handlers/transaction.rs
@@ -37,6 +37,15 @@ impl IntoResponse for AppError {
 }
 
 // A function that takes a transaction from a user and saves it permanently to MongoDB
+#[utoipa::path(
+    post,
+    path = "/transactions",
+    request_body = CreateTransactionInput,
+    responses(
+        (status = 200, description = "Transaction created successfully"),
+        (status = 400, description = "invalid input")
+    )
+)]
 pub async fn create_transaction(State(client): State<Client>, Json(payload): Json<CreateTransactionInput>) -> Result<(StatusCode, Json<serde_json::Value>), AppError> {
 
     // Amount validation
@@ -93,6 +102,13 @@ pub async fn create_transaction(State(client): State<Client>, Json(payload): Jso
 }
 
 //A function that returens all stored transacions
+#[utoipa::path(
+    get,
+    path = "/transactions",
+    responses(
+        (status = 200, description = "List of transactions retrieved successfully")
+    )
+)]
 pub async fn get_transactions(State(client): State<Client>, Query(params): Query<TransactionQuery>) -> Result<(StatusCode, Json<serde_json::Value>), AppError> {
     let database = client.database("blockchain");
     let collection = database.collection("transactions");
@@ -144,6 +160,15 @@ pub async fn get_transactions(State(client): State<Client>, Query(params): Query
 }
 
 // A function that returns a trasaction based on ID.
+#[utoipa::path(
+    get,
+    path = "/transactions/{id}",
+    responses(
+        (status = 200, description = "Transaction found"),
+        (status = 400, description = "invalid ID format, please provide 13612637127132"),
+        (status = 404, description = "Transaction not found")
+    )
+)]
 pub async fn get_transaction_by_id(State(client): State<Client>, Path(id): Path<String>) -> Result<(StatusCode, Json<serde_json::Value>), AppError> {
     let object_id = match ObjectId::parse_str(id) {
         Ok(id) => id, // Succces - use the ObjectID
@@ -167,6 +192,15 @@ pub async fn get_transaction_by_id(State(client): State<Client>, Path(id): Path<
 }
 
 //A function that delets a transaction by ID.
+#[utoipa::path(
+    delete,
+    path = "/transactions/{id}",
+    responses(
+        (status = 200, description = "Transaction deleted successfully"),
+        (status = 400, description = "invalid ID format, please provide 13612637127132"),
+        (status = 404, description = "Transaction not found")
+    )
+)]
 pub async fn delete_transaction_by_id(State(client): State<Client>, Path(id): Path<String>) -> Result<(StatusCode, Json<serde_json::Value>), AppError> {
     let object_id = match ObjectId::parse_str(id) {
         Ok(id) => id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,27 @@ use axum::{
 
 use mongodb::{Client, bson::doc, IndexModel};
 use serde_json::json;
+use utoipa::{OpenApi};
+use crate::models::transaction::CreateTransactionInput;
+use utoipa_swagger_ui::SwaggerUi;
+
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        transaction::create_transaction,
+        transaction::get_transactions,
+        transaction::get_transaction_by_id,
+        transaction::delete_transaction_by_id
+    ),
+    components(
+        schemas(Transaction, CreateTransactionInput)
+    ),
+    tags(
+        (name = "transaction", description = "Transaction management endpoints")
+    )
+)]
+struct ApiDoc;
 
 async fn root() -> Json<serde_json::Value> {
     Json(json!(
@@ -87,6 +108,7 @@ async fn main() {
     let user_request = Router::new()
         // stores the client in Axum's state manager
         .route("/", get(root))
+        .merge(SwaggerUi::new("/docs").url("/api-docs/openapi.json", ApiDoc::openapi()))
         .route("/transactions", get(transaction::get_transactions))
         .route("/transactions", post(transaction::create_transaction))
         .route(

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -4,6 +4,5 @@ pub mod transaction;
 pub mod query;
 
 pub use block::Block;
-pub use blockchain::Blockchain;
 pub use transaction::Transaction;
 pub use query::TransactionQuery;

--- a/src/models/transaction.rs
+++ b/src/models/transaction.rs
@@ -1,8 +1,10 @@
 use mongodb::bson::oid::ObjectId;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
 pub struct Transaction {
+    #[schema(value_type = String)]
     #[serde(rename = "_id")]
     pub id: ObjectId,
     pub tx_id: u64,
@@ -12,7 +14,7 @@ pub struct Transaction {
     pub timestamp: u64,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, ToSchema)]
 pub struct CreateTransactionInput {
     pub sender: String,
     pub receiver: String,


### PR DESCRIPTION
## ✅ Issue Complete

### What was implemented:
- Added `utoipa` and `utoipa-swagger-ui` dependencies
- Documented all models (`Transaction`, `CreateTransactionInput`) with `#[derive(ToSchema)]`
- Added `#[utoipa::path(...)]` annotations to all 4 handler functions:
  - `create_transaction` (POST /transactions)
  - `get_transactions` (GET /transactions)
  - `get_transaction_by_id` (GET /transactions/{id})
  - `delete_transaction_by_id` (DELETE /transactions/{id})
- Created OpenAPI specification in `main.rs`
- Mounted Swagger UI at `/docs` endpoint

### How to use:
1. Start the server: `cargo run`
2. Visit: http://localhost:3000/docs
3. Interactive API documentation with "Try it out" functionality
